### PR TITLE
fix zmk code block formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A small 'hat' that sits ontop of the nice!nano to support a nice!view
 
 
 ## ZMK
-
+```
 nice_view_spi: &spi0 {
 
     compatible = "nordic,nrf-spim";
@@ -19,7 +19,7 @@ nice_view_spi: &spi0 {
     cs-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
 
 };  
-
+```
 ### NB
 
 This hat might, in theory, effect the signal strength of the nice!nano, I haven't experiened this, some minor efforts have been made to reduce any effects, but I'm just saying.


### PR DESCRIPTION
autoformatting was kicking in, but wasn't formatting first and last lines, so I wrapped it in some ticks.