### PR TITLE
zmk shield module for nicehatharry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,5 @@
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  build:
+    uses: zmkfirmware/zmk/.github/workflows/build-user-config.yml@main

--- a/README.md
+++ b/README.md
@@ -3,36 +3,35 @@
 A small 'hat' that sits ontop of the nice!nano to support a nice!view
 
 ## ZMK (version >= 3.2)
-```
-&pinctrl {
-    spi0_default: spi0_default {
-        group1 {
-            psels = <NRF_PSEL(SPIM_SCK, 1, 2)>,
-                <NRF_PSEL(SPIM_MOSI, 1, 7)>,
-                <NRF_PSEL(SPIM_MISO, 0, 19)>; /* GPIO0 19 is not broken on a nice!nano.*/
-        };
-    };
-    spi0_sleep: spi0_sleep {
-        group1 {
-            psels = <NRF_PSEL(SPIM_SCK, 1, 2)>,
-                <NRF_PSEL(SPIM_MOSI, 1, 7)>,
-                <NRF_PSEL(SPIM_MISO, 0, 19)>; /* GPIO0 19 is not broken on a nice!nano.*/
-            low-power-enable;
-        };
-    };
-};
 
+In your zmk-config repo, in `config/west.yml` file:
 
-nice_view_spi: &spi0 {
-    compatible = "nordic,nrf-spim";
-    pinctrl-0 = <&spi0_default>;
-    pinctrl-1 = <&spi0_sleep>;
-    pinctrl-names = "default", "sleep";
-    cs-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
-};
+In `manifest.remotes`
 
 ```
+    - name: davidphilipbarr
+      url-base: https://github.com/davidphilipbarr
+```
 
+And then in `manifest.projects`:
+
+```
+    - name: nicehatharry
+      remote: davidphilipbarr
+      clone-depth: 1
+      revision: main
+````
+
+And finally, in `build.yaml`:
+
+```
+    - board: nice_nano_v2
+      shield: reviung34 nicehatharry nice_view
+```
+
+Place the `nicehatharry` in place of the nice_view_adapter from the nice_view instructions.
+
+ 
 ## ZMK (version < 3.2)
 ```
 nice_view_spi: &spi0 {

--- a/boards/shields/nicehatharry/Kconfig.defconfig
+++ b/boards/shields/nicehatharry/Kconfig.defconfig
@@ -1,0 +1,2 @@
+if SHIELD_NICEHATHARRY
+endif

--- a/boards/shields/nicehatharry/Kconfig.shield
+++ b/boards/shields/nicehatharry/Kconfig.shield
@@ -1,2 +1,2 @@
 config SHIELD_NICEHATHARRY
-	def_bool $(shield_list_contains,nicehatharry)
+	def_bool $(shields_list_contains,nicehatharry)

--- a/boards/shields/nicehatharry/Kconfig.shield
+++ b/boards/shields/nicehatharry/Kconfig.shield
@@ -1,0 +1,2 @@
+config SHIELD_NICEHATHARRY
+	def_bool $(shield_list_contains,nicehatharry)

--- a/boards/shields/nicehatharry/nicehatharry.overlay
+++ b/boards/shields/nicehatharry/nicehatharry.overlay
@@ -1,0 +1,27 @@
+&pinctrl {
+    spi0_default: spi0_default {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 1, 2)>,
+                <NRF_PSEL(SPIM_MOSI, 1, 7)>,
+                <NRF_PSEL(SPIM_MISO, 0, 19)>; /* GPIO0 19 is not broken on a nice!nano.*/
+        };
+    };
+    spi0_sleep: spi0_sleep {
+        group1 {
+            psels = <NRF_PSEL(SPIM_SCK, 1, 2)>,
+                <NRF_PSEL(SPIM_MOSI, 1, 7)>,
+                <NRF_PSEL(SPIM_MISO, 0, 19)>; /* GPIO0 19 is not broken on a nice!nano.*/
+            low-power-enable;
+        };
+    };
+};
+
+
+nice_view_spi: &spi0 {
+    compatible = "nordic,nrf-spim";
+    pinctrl-0 = <&spi0_default>;
+    pinctrl-1 = <&spi0_sleep>;
+    pinctrl-names = "default", "sleep";
+    cs-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
+};
+

--- a/boards/shields/nicehatharry/nicehatharry.zmk.yml
+++ b/boards/shields/nicehatharry/nicehatharry.zmk.yml
@@ -1,0 +1,7 @@
+file_format: "1"
+id: nicehatharry
+name: nicehatharry
+type: shield
+url: https://github.com/davidphilipbarr/nicehatharry
+requires: [i2c_oled]
+exposes: [nice_view_header]

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,22 @@
+# This file generates the GitHub Actions matrix.
+# For simple board + shield combinations, add them to the top level board and
+# shield arrays, for more control, add individual board + shield combinations
+# to the `include` property. You can also use the `cmake-args` property to
+# pass flags to the build command and `artifact-name` to assign a name to
+# distinguish build outputs from each other:
+#
+# board: [ "nice_nano_v2" ]
+# shield: [ "corne_left", "corne_right" ]
+# include:
+#   - board: bdn9_rev2
+#   - board: nice_nano_v2
+#     shield: reviung41
+#   - board: nice_nano_v2
+#     shield: corne_left
+#     cmake-args: -DCONFIG_ZMK_USB_LOGGING=y
+#     artifact-name: corne_left_with_logging
+#
+---
+include:
+  - board: nice_nano_v2
+    shield: nicehatharry

--- a/config/west.yml
+++ b/config/west.yml
@@ -1,0 +1,13 @@
+manifest:
+  remotes:
+    - name: zmkfirmware
+      url-base: https://github.com/zmkfirmware
+    # Additional modules containing boards/shields/custom code can be listed here as well
+    # See https://docs.zephyrproject.org/3.2.0/develop/west/manifest.html#projects
+  projects:
+    - name: zmk
+      remote: zmkfirmware
+      revision: main
+      import: app/west.yml
+  self:
+    path: config

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,3 @@
+build:
+  settings:
+    board_root: .


### PR DESCRIPTION
This creates a zmk module that can be included for builds that use a nicehatharry to make it real easy to integrate into the firmware.

I also updated the README with instructions.

I'm not gonna lie, I probably misspelled your name about a dozen times in here so you might want to double check that haha