### PR TITLE
fix(module): minor fixes to get nicehatharry working as zmk module

### DIFF
--- a/boards/shields/nicehatharry/nicehatharry.conf
+++ b/boards/shields/nicehatharry/nicehatharry.conf
@@ -1,0 +1,2 @@
+# Disable OLED
+CONFIG_SSD1306=n

--- a/boards/shields/nicehatharry/nicehatharry.overlay
+++ b/boards/shields/nicehatharry/nicehatharry.overlay
@@ -25,3 +25,6 @@ nice_view_spi: &spi0 {
     cs-gpios = <&gpio1 1 GPIO_ACTIVE_HIGH>;
 };
 
+&pro_micro_i2c {
+    status = "disabled";
+};


### PR DESCRIPTION
- disable i2c to prevent compilation error (cf. https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/nice_view_adapter/boards/nice_nano_v2.overlay#L33)

```
...
static assertion failed: "Only one of the following peripherals can be
enabled: SPI0, SPIM0, SPIS0, TWI0, TWIM0, TWIS0. Check nodes with status
\"okay\" in zephyr.dts."
...
```

- explicitly disable OLED (cf. https://github.com/zmkfirmware/zmk/blob/main/app/boards/shields/nice_view_adapter/nice_view_adapter.conf)

```
...
/__w/zmk-config/zmk-config/zephyr/drivers/display/ssd1306.c:518:1: note:
in expansion of macro 'DT_FOREACH_STATUS_OKAY'
  518 | DT_FOREACH_STATUS_OKAY(solomon_ssd1306fb, SSD1306_DEFINE)
      | ^~~~~~~~~~~~~~~~~~~~~~
...
```